### PR TITLE
Import webthing-iotjs to iotjs-modules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -27,3 +27,6 @@
 [submodule "mastodon-lite"]
 	path = mastodon-lite
 	url = https://github.com/rzr/mastodon-lite
+[submodule "webthing-iotjs"]
+	path = webthing-iotjs
+	url = https://github.com/rzr/webthing-iotjs


### PR DESCRIPTION
Origin: https://github.com/rzr/webthing-iotjs
Bug: https://github.com/jerryscript-project/iotjs-modules/pull
Change-Id: I78cb57236f4cc828c2ed32b1f903dcc5ef7f62f7
IoT.js-Modules-DCO-1.0-Signed-off-by: Philippe Coval p.coval@samsung.com