### PR TITLE
Import generic-sensors-lite to iotjs-modules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -30,3 +30,6 @@
 [submodule "webthing-iotjs"]
 	path = webthing-iotjs
 	url = https://github.com/rzr/webthing-iotjs
+[submodule "generic-sensors-lite"]
+	path = generic-sensors-lite
+	url = https://github.com/rzr/generic-sensors-lite


### PR DESCRIPTION
Gemeric sensor sdk

This module relis on nore external modules
that will be installed using makefile.

Relate-to: https://hub.samsunginter.net/adding-sensors-to-the-web-of-things/
Origin: https://github.com/rzr/generic-sensors-lite
Change-Id: I679795a28facbe80e1c868ea6357f32091e2ad7b
Bug: https://github.com/jerryscript-project/iotjs-modules/pull
IoT.js-Modules-DCO-1.0-Signed-off-by: Philippe Coval p.coval@samsung.com