### PR TITLE
Import twins to iotjs-modules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -33,3 +33,6 @@
 [submodule "generic-sensors-lite"]
 	path = generic-sensors-lite
 	url = https://github.com/rzr/generic-sensors-lite
+[submodule "twins"]
+	path = twins
+	url = https://github.com/rzr/twins


### PR DESCRIPTION
Origin: https://github.com/rzr/twins
Relate-to: https://social.samsunginter.net/@rzr/102139995659879619
Bug: https://github.com/jerryscript-project/iotjs-modules/pull
Change-Id: Ic054437864b54a2f95d47f393da796d7d2daefa2
IoT.js-Modules-DCO-1.0-Signed-off-by: Philippe Coval p.coval@samsung.com